### PR TITLE
feat: auto-sync upstream

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,20 @@
+name: Sync to upstream
+
+# Run once a day or manually
+on:
+  # Run once a day
+  pull_request: # I will remove this once I validate it works
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  sync_upstream:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          gh api --method POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          /repos/ShieldedLabs/zebra-crosslink-staging/merge-upstream \
+          -f "branch=master"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,8 +2,6 @@ name: Sync to upstream
 
 # Run once a day or manually
 on:
-  # Run once a day
-  pull_request: # I will remove this once I validate it works
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,9 @@ on:
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:
+  
+env:
+    GH_TOKEN: ${{ github.token }}
 
 jobs:
   sync_upstream:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,4 +20,4 @@ jobs:
           -H "Accept: application/vnd.github+json" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
           /repos/ShieldedLabs/zebra-crosslink-staging/merge-upstream \
-          -f "branch=master"
+          -f "branch=main"


### PR DESCRIPTION
This PR is a proposal to automatically sync our fork to upstream once a day using the GitHub API.

This is triggered via a midnight cron or a manual dispatch.

Potentially closes https://github.com/ShieldedLabs/zebra-crosslink/issues/7, although we may want to implement this on `zebra-crosslink` as well. I would argue, however, that we WANT to manually sync `zebra-crosslink` because we're going to want to pay attention to it and be quite intentional about when we sync.