### PR TITLE
Fix Height arithmetic in chain tip checks

### DIFF
--- a/zebra-state/src/service/chain_tip.rs
+++ b/zebra-state/src/service/chain_tip.rs
@@ -594,17 +594,17 @@ impl ChainTipChange {
         // So we must perform the same actions for network upgrades and skipped blocks.
         let is_activation = NetworkUpgrade::is_activation_height(&self.network, block.height);
         let is_parent = Some(block.previous_block_hash) == self.last_change_hash;
-        let is_sequential = self
-            .last_change_height
-            .map_or(false, |h| block.height == h + 1);
+        let is_sequential = self.last_change_height.map_or(false, |h| {
+            block.height == (h + 1).expect("heights are valid")
+        });
 
         if is_parent && is_sequential && !is_activation {
             TipAction::grow_with(block)
         } else {
             let rollback = !is_parent
-                && self
-                    .last_change_height
-                    .map_or(false, |h| block.height <= h + 1);
+                && self.last_change_height.map_or(false, |h| {
+                    block.height <= (h + 1).expect("heights are valid")
+                });
             TipAction::reset_with_reason(block, rollback)
         }
     }

--- a/zebra-state/src/service/chain_tip/tests/prop.rs
+++ b/zebra-state/src/service/chain_tip/tests/prop.rs
@@ -135,12 +135,15 @@ proptest! {
                 } else {
                     let is_activation = NetworkUpgrade::is_activation_height(&network, chain_tip.height);
                     let is_parent = Some(chain_tip.previous_block_hash) == old_last_change_hash;
-                    let is_sequential = old_last_change_height.map_or(false, |h| chain_tip.height == h + 1);
+                    let is_sequential = old_last_change_height
+                        .map_or(false, |h| chain_tip.height == (h + 1).expect("heights are valid"));
 
                     if is_parent && is_sequential && !is_activation {
                         Some(TipAction::grow_with(block.0.into()))
                     } else {
-                        let rollback = !is_parent && old_last_change_height.map_or(false, |h| chain_tip.height <= h + 1);
+                        let rollback = !is_parent
+                            && old_last_change_height
+                                .map_or(false, |h| chain_tip.height <= (h + 1).expect("heights are valid"));
                         Some(TipAction::reset_with_reason(block.0.into(), rollback))
                     }
                 }


### PR DESCRIPTION
## Summary
- ensure addition on `Height` handles overflow using `expect`

## Testing
- `cargo +1.87.0 fmt`
- ❌ `cargo +1.87.0 test -p zebra-state --lib chain_tip:: --no-run --locked` *(fails: no matching package named `atty`)*

------
https://chatgpt.com/codex/tasks/task_e_688786ed7fec832d81a4a7c1346f502f