### PR TITLE
Fix gossip tip reset logs

### DIFF
--- a/zebra-state/src/service/chain_tip.rs
+++ b/zebra-state/src/service/chain_tip.rs
@@ -669,6 +669,22 @@ impl ChainTipChange {
     pub fn latest_chain_tip(&self) -> LatestChainTip {
         self.latest_chain_tip.clone()
     }
+
+    /// Clone this [`ChainTipChange`], keeping the last observed tip.
+    ///
+    /// The standard [`Clone`] implementation resets the tip tracking so the
+    /// first call to [`wait_for_tip_change`](Self::wait_for_tip_change) returns a
+    /// [`Reset`]. This helper preserves `last_change_hash` and
+    /// `last_change_height` so clones continue tracking the chain without a
+    /// spurious reset.
+    pub fn clone_with_tip(&self) -> Self {
+        Self {
+            latest_chain_tip: self.latest_chain_tip.clone(),
+            last_change_hash: self.last_change_hash,
+            last_change_height: self.last_change_height,
+            network: self.network.clone(),
+        }
+    }
 }
 
 impl Clone for ChainTipChange {

--- a/zebrad/src/components/sync/gossip.rs
+++ b/zebrad/src/components/sync/gossip.rs
@@ -63,7 +63,7 @@ where
 
     loop {
         let mut sync_status = sync_status.clone();
-        let mut chain_tip = chain_state.clone();
+        let mut chain_tip = chain_state.clone_with_tip();
         let tip_change_close_to_network_tip_fut = async move {
             // wait for at least one tip change, to make sure we have a new block hash to broadcast
             let tip_action = chain_tip.wait_for_tip_change().await.map_err(TipChange)?;


### PR DESCRIPTION
## Summary
- add `clone_with_tip` helper to `ChainTipChange`
- use it in `gossip_best_tip_block_hashes` so clones keep the last tip

## Testing
- `cargo test -p zebra-state --lib` *(fails: tunnel error)*
- `cargo check -p zebra-state --lib` *(fails: tunnel error)*

------
https://chatgpt.com/codex/tasks/task_e_688bac633754832da6ff50c2393c417c